### PR TITLE
Use the image from cloudservices repo on quay.io

### DIFF
--- a/clowdapp.yaml
+++ b/clowdapp.yaml
@@ -80,7 +80,7 @@ parameters:
     value: 'latest'
     required: true
   - name: IMAGE
-    value: quay.io/ckyrouac/xjoin-api-gateway
+    value: quay.io/cloudservices/xjoin-api-gateway
 
   - description : ClowdEnvironment name
     name: ENV_NAME


### PR DESCRIPTION
Update image to because quay.io/ckyrouace/xjoin-api-gateway image is not accessible leading to deployment failures in Minikube